### PR TITLE
Add `LevelingFramework` Requirement to Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 **customAlchemy** reimpliments vanilla alchemy mechanics to allow batch potion brewing, server side customization and improvement of server performance.
 
-Requires [DataManager](https://github.com/tes3mp-scripts/DataManager), [GuiFramework](https://github.com/tes3mp-scripts/GuiFramework), [ContainerFramework](https://github.com/tes3mp-scripts/ContainerFramework) and optionally [QuickKeyCleaner](https://github.com/tes3mp-scripts/QuickKeyCleaner), [espParser](https://github.com/JakobCh/tes3mp_scripts/tree/master/espParser)!
+Requires [DataManager](https://github.com/tes3mp-scripts/DataManager), [GuiFramework](https://github.com/tes3mp-scripts/GuiFramework), [ContainerFramework](https://github.com/tes3mp-scripts/ContainerFramework), [LevelingFramework](https://github.com/tes3mp-scripts/LevelingFramework) and optionally [QuickKeyCleaner](https://github.com/tes3mp-scripts/QuickKeyCleaner), [espParser](https://github.com/JakobCh/tes3mp_scripts/tree/master/espParser)!
 
 Most of the formulas are contained in `formulas.lua` for (relatively) easy access.
 


### PR DESCRIPTION
While looking over the `LevelingFramework` module readme, I noticed it mentions that `CustomAlchemy` uses the `LevelingFramework` module, however it does not mention this in the requirements at the top of the README. Here in [main.lua](https://github.com/tes3mp-scripts/CustomAlchemy/blob/b4d493cb811eed67c4079259194ae7f0b2c487e3/main.lua#L634) LevelingFramework is referenced however. This pull request takes care of that. 

On another note... thanks for the awesome work too btw :tada: !